### PR TITLE
feat: bulk search with subdeck info in find_similar_notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,25 +292,27 @@ Updates multiple notes in a single batch operation for maximum efficiency.
 
 ### `find_similar_notes`
 
-Find notes containing any of the search terms. Returns results grouped by term, with deck info.
+Find notes containing any of the search terms. Returns results grouped by term, with subdeck info.
 
 **Parameters**:
 
-- `deck_name` (str): Name of the Anki deck to search in
+- `deck_name` (str): Name of the Anki deck to search in (used as a filter)
 - `search_terms` (list[str]): List of terms to search for as substrings in any field
 - `case_sensitive` (bool, optional): Whether the search should be case sensitive (default: false)
 - `max_results_per_term` (int, optional): Maximum number of matching notes to return per search term (default: 20)
 
-**Returns**: Results grouped by search term, each match includes `deck_name` showing which subdeck the note belongs to
+**Returns**: Results grouped by search term. The top-level `deck_name` is the input filter; each match includes `deck_names` (list) showing all decks the note's cards belong to.
 
 **Features**:
 
 - Bulk search: check multiple terms in a single call
-- Returns subdeck info for each match
+- Returns all deck names per match (useful for filtered decks and nested hierarchies)
 - Fast substring matching across all note fields
 - Case-sensitive or case-insensitive search options
 - Shows exactly which fields matched the search criteria
 - Uses only local AnkiConnect (no external APIs)
+
+**Note**: Tags are not returned (uses cardsInfo API for subdeck support).
 
 ## Technical Details
 

--- a/README.md
+++ b/README.md
@@ -292,23 +292,25 @@ Updates multiple notes in a single batch operation for maximum efficiency.
 
 ### `find_similar_notes`
 
-Finds notes that contain the search text as a substring in any field. Simple and reliable text matching.
+Find notes containing any of the search terms. Returns results grouped by term, with deck info.
 
 **Parameters**:
 
 - `deck_name` (str): Name of the Anki deck to search in
-- `search_text` (str): Text to search for as a substring in any field
+- `search_terms` (list[str]): List of terms to search for as substrings in any field
 - `case_sensitive` (bool, optional): Whether the search should be case sensitive (default: false)
-- `max_results` (int, optional): Maximum number of matching notes to return (default: 20)
+- `max_results_per_term` (int, optional): Maximum number of matching notes to return per search term (default: 20)
 
-**Returns**: JSON object with matching notes and details about which fields contained the search text
+**Returns**: Results grouped by search term, each match includes `deck_name` showing which subdeck the note belongs to
 
 **Features**:
 
+- Bulk search: check multiple terms in a single call
+- Returns subdeck info for each match
 - Fast substring matching across all note fields
 - Case-sensitive or case-insensitive search options
 - Shows exactly which fields matched the search criteria
-- No external API dependencies required
+- Uses only local AnkiConnect (no external APIs)
 
 ## Technical Details
 


### PR DESCRIPTION
Refactors `find_similar_notes` to accept a list of search terms instead of a single string, allowing bulk duplicate/existence checks in one call. Results are now grouped by term.

Also switches from `notesInfo` to `cardsInfo` under the hood so each match includes the actual subdeck name—useful when searching across a parent deck that contains nested subdecks.

Note: switch sacrificed tags from inclusion in results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk search: query multiple terms at once and get results grouped by term.
  * Each match includes deck/subdeck context so you can see where results come from.

* **Changes**
  * API and responses now return per-term grouped results with improved metadata (counts, terms searched, matches per term).
  * Empty-term queries return a clear error structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->