### PR TITLE
fix(elevenlabs): default to Flash v2.5 instead of deprecated Turbo

### DIFF
--- a/anki_mcp_elevenlabs/tts/elevenlabs_tts.py
+++ b/anki_mcp_elevenlabs/tts/elevenlabs_tts.py
@@ -23,10 +23,10 @@ async def generate_elevenlabs_audio(
             "ELEVENLABS_VOICE_ID", "aEO01A4wXwd1O8GPgGlF"
         )  # Default Arabella (English). For Spanish, use: hEKEQC93QpOYMa6WuwWp
 
-    # Turbo v2.5 honors language_code (Multilingual v2 silently ignores it),
+    # Flash v2.5 honors language_code (Multilingual v2 silently ignores it),
     # so we default to it to enforce the language set below.
     if model is None:
-        model = "eleven_turbo_v2_5"
+        model = "eleven_flash_v2_5"
 
     try:
         url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"


### PR DESCRIPTION
## Summary

Turbo v2.5 (our TTS default) is deprecated. Switch to Flash v2.5 — the recommended, functionally-equivalent replacement: lower latency, ~50% cheaper, and it still honors `language_code`, so language enforcement is unchanged.

## Manually Tested

- Flash pronounces vocab words correctly and sounds good on the deck voice (compared several takes against Turbo).
